### PR TITLE
Added error images for Linux OS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var growl = require('growl');
-var isDarwin = process.platform === 'darwin';
+var os = require('os');
+var isDarwin = process.platform === 'Linux';
 
 function successIcon() {
   return isDarwin ? '✅' : '';
@@ -10,26 +11,43 @@ function errorIcon() {
   return isDarwin ? '🚫' : '';
 }
 
+function errorImage() {
+    if (os.type() == 'Linux') {
+        return 'dialog-error';
+    }
+    return '';
+}
+
+function successImage() {
+    if (os.type() == 'Linux') {
+        return 'dialog-ok';
+    }
+    return '';
+}
+
 var GrowlNotificationsReporter = function(helper, logger) {
   this.onBrowserComplete = function(browser) {
     var results = browser.lastResult;
     var time = helper.formatTimeInterval(results.totalTime);
-    var title, message;
+    var title, message, icon = '';
 
     if (results.disconnected || results.error) {
       title = util.format('ERROR - %s', browser.name);
       message = 'Test error';
+      icon = errorImage();
     }
     else if (results.failed) {
       title = util.format('%s FAILED - %s', errorIcon(), browser.name);
       message = util.format('%d/%d tests failed in %s.', results.failed, results.total, time);
+      icon = errorImage();
     }
     else {
       title = util.format('%s PASSED - %s', successIcon(), browser.name);
       message = util.format('%d tests passed in %s.', results.success, time);
+      icon = successImage();
     }
 
-    growl(message, {title: title});
+    growl(message, {title: title, image: icon});
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var growl = require('growl');
 var os = require('os');
-var isDarwin = process.platform === 'Linux';
+var isDarwin = process.platform === 'darwin';
 
 function successIcon() {
   return isDarwin ? '✅' : '';


### PR DESCRIPTION
Hi,

I added custom icons for Linux OS for both failing and successing. They show up bigger and in colors (green checkmark, or red one-way sign). It can be extended for other operating systems, but i don't know commands for showing different types of errors on those, so this works only for Linux.
